### PR TITLE
fix:missing start script & 'npm install' instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Install NodeJS
 - Clone this project
 - Type `cd <folder's name created from clone>`
 - Maximize your terminal/console
+- Type `npm install`
 - Type `npm start`
 - Be ready for random letter
 - Start to write

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Para el basta",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start":"node index.js"
   },
   "author": "Erubiel Recoba",
   "license": "ISC",


### PR DESCRIPTION
 💡  **Context**
 In my runtime environment when I try to run `npm start` the application throws an error because the "start" script is missing in the "package.json"

☕ **Approach**
* Write the line for script "start"
* plus: Add a line to the readme for install modules before the run start script 
